### PR TITLE
Avoid copyfile, use check_call cp instead

### DIFF
--- a/carbonate/sync.py
+++ b/carbonate/sync.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import logging
-import shutil
 import subprocess
 from time import time
 from datetime import timedelta
@@ -77,8 +76,8 @@ def heal_metric(source, dest):
                 except os.error:
                     pass
                 try:
-                    shutil.copyfile(source, dest)
-                except IOError as e:
+                    subprocess.check_call(['cp', source, dest])
+                except subprocess.CalledProcessError as e:
                     logging.warn("Failed to copy %s! %s" % (dest, e))
     except IOError:
         try:
@@ -86,8 +85,8 @@ def heal_metric(source, dest):
         except os.error:
             pass
         try:
-            shutil.copyfile(source, dest)
-        except IOError as e:
+            subprocess.check_call(['cp', source, dest])
+        except subprocess.CalledProcessError as e:
             logging.warn("Failed to copy %s! %s" % (dest, e))
 
 


### PR DESCRIPTION
Will end up creating sub-processes for each copy, but that seems to be the best
option to preserve sparse files. cp by default uses auto-detection of sparse
files. If this isn't enough we can force it with `--spare=always`

fixes #57